### PR TITLE
Load Single Species

### DIFF
--- a/Diagnostics/LoadProfile.py
+++ b/Diagnostics/LoadProfile.py
@@ -1,0 +1,128 @@
+# Written by Daniel Duque
+# Last modified on 06/03/2020
+# Diagnostic tools for a plasma loaded from an MCP profile
+
+import csv
+import matplotlib
+import matplotlib.animation
+import math
+import copy
+import numpy
+import scipy.fftpack
+from scipy import signal
+from scipy.constants import Boltzmann
+from mpl_toolkits import mplot3d
+
+#----------------------------------------------
+#INPUT:
+#Name of the files where the data from the simulation was stored:
+positionsFile = "PositionsElectrons.csv"
+initialDensityFile = "Initial Density Estimate.csv"
+trapParametersFile = "Trap Parameters.csv"
+plasmaParametersFile = "ElectronsParameters.csv"
+
+#Output parameters
+
+#Do you want to plot the electrostatic potential of the trap
+plotTrapPotential = True
+saveFileNameInitialDensity = 'Initial Density 3.png'
+#----------------------------------------------
+#Data unpacking
+#----------------------------------------------
+#Unpack parameters of the trap. Look at the C++ output for the extract method to see how the parameters are formatted in the file
+trapParametersMatrix = list(csv.reader(open(trapParametersFile), delimiter=','))
+for row in trapParametersMatrix:
+    for i in range(len(row)):
+        row[i] = float(row[i])
+#See in C++ extract what each number represents
+trapRadius = trapParametersMatrix[0][0]
+Nz, Nr = trapParametersMatrix[3]
+hz, hr = trapParametersMatrix[4]
+trapLength = trapParametersMatrix[5][0]
+#Same as for trap parameters
+plasmaParametersMatrix = list(csv.reader(open(plasmaParametersFile), delimiter=','))
+for row in plasmaParametersMatrix:
+    for i in range(len(row)):
+        row[i] = float(row[i])
+massSingle = plasmaParametersMatrix[0][0]
+chargeSingle = plasmaParametersMatrix[1][0]
+chargeMacro = plasmaParametersMatrix[2][0]
+massMacro = massSingle * chargeMacro / chargeSingle;
+macroChargeDensity = 4 * chargeMacro / (math.pi * hz * hr * hr)
+#Read the positions, the first element corresponds to the radius index in the trap grid
+#Remove the last element. We have one less speed from before, then make them all the same length as the speeds matrix
+positionsMatrix = list(csv.reader(open(positionsFile), delimiter=','))
+for row in positionsMatrix:
+    if len(row) != 2:
+        del row[len(row) - 1]
+    for i in range(len(row)):
+        row[i] = float(row[i])
+#Read initial density estimate, remember it is embeded as a 1d array
+transitionMatrix = list(csv.reader(open(initialDensityFile), delimiter=','))
+for row in transitionMatrix:
+    for i in range(len(row)):
+        row[i] = float(row[i]) / chargeSingle
+#Now arrange the 1D array as an appropriate 2D array as the trap grid
+initialDensityEstimateMatrix = []
+for i in range(len(transitionMatrix)):
+    if i % (Nz + 1) == 0:
+        aRow = []
+        aRow.append(transitionMatrix[i][0])
+        initialDensityEstimateMatrix.append(aRow)
+    else:
+        initialDensityEstimateMatrix[-1].append(transitionMatrix[i][0])
+#------------------------------------------------
+#Different things you can get:
+#------------------------------------------------   
+#------------------------------------------------   
+#Initial Distribution
+#------------------------------------------------
+#Compare the estimated initial density with that obtained from the particle loading
+#Plot initial estimate
+
+x = numpy.linspace(0, trapLength, num = int(Nz + 1))
+y = numpy.linspace(0, trapRadius, num = int(Nr), endpoint = False)
+X, Y = numpy.meshgrid(x, y)
+figInitialDensity = matplotlib.pyplot.figure()
+ax1 = figInitialDensity.add_subplot(2, 1, 1, projection='3d')
+ax1.plot_surface(X, Y, numpy.array(initialDensityEstimateMatrix), rstride=1, cstride=1,
+                cmap='plasma', edgecolor='none')
+ax1.set_title('Estimated Initial Density')
+ax1.set_xlabel('z (m)')
+ax1.set_ylabel('r (m)')
+ax1.set_zlabel('n (part/m^3)')
+ax1.ticklabel_format(style='sci', scilimits=(0,0))
+
+#Now plot the obtained from macro particles
+particleDensity = numpy.zeros((int(Nr), int(Nz + 1)))
+'''
+int indexR{ aRing.getR() };
+int indexZ{ (int)floor(aRing.getZ() / hz) };
+int indexRHS{ (refTrap.Nz + 1) * indexR + indexZ };
+double z{ aRing.getZ() - indexZ * hz };//Distance from left grid point to particle
+double weightFactor{ z / hz };//Weight going to grid point on the right (number between 0 and 1)
+RHS.coeffRef(indexRHS) += -macroChargeDensity * (1 - weightFactor) / epsilon;//Point to the left
+RHS.coeffRef(indexRHS + 1) += -macroChargeDensity * weightFactor / epsilon;//Point to the right
+'''
+for row in positionsMatrix:
+    indexR = int(row[0])
+    indexZ = int(numpy.floor(row[1] / hz))
+    z = row[1] - indexZ * hz
+    weightFactor = z / hz
+    particleDensity[indexR,indexZ] += (1 - weightFactor) * macroChargeDensity / chargeSingle
+    particleDensity[indexR,indexZ + 1] += weightFactor * macroChargeDensity / chargeSingle
+x = numpy.linspace(0, trapLength, num = int(Nz + 1))
+y = numpy.linspace(0, trapRadius, num = int(Nr), endpoint = False)
+X, Y = numpy.meshgrid(x, y)
+ax2 = figInitialDensity.add_subplot(2, 1, 2, projection='3d')
+ax2.plot_surface(X, Y, particleDensity, rstride=1, cstride=1,
+                cmap='plasma', edgecolor='none')
+ax2.set_title('Initial Density Distribution')
+ax2.set_xlabel('z (m)')
+ax2.set_ylabel('r (m)')
+ax2.set_zlabel('n (part/m^3)')
+ax2.ticklabel_format(style='sci', scilimits=(0,0))
+matplotlib.pyplot.tight_layout()
+matplotlib.pyplot.savefig(saveFileNameInitialDensity)
+        
+        

--- a/Source/Constants.hpp
+++ b/Source/Constants.hpp
@@ -1,6 +1,6 @@
 /*
 Written by: Daniel Duque
-Last modified on 04 Mar 2020
+Last modified on 06 Mar 2020
 
 Declarations for the Plasma class
 This file contains a corresponding source file.
@@ -12,7 +12,7 @@ This file contains a corresponding source file.
 const double ePos{ 1.602176634e-19 }; //Elementary positive charge in Coulombs
 const double epsilon{ 8.8541878128e-12 }; //Permittivity of free space in SI units
 const double massE{ 9.1093837015e-31 }; //Electron rest mass in kilograms
-const double PI{ 3.14159265359 };
-const double KB{ 1.38064852e-23 }; //Boltzmann constant in SI
+const double PI{ 3.141592653589793238463 };
+const double KB{ 1.380649e-23 }; //Boltzmann constant in SI
 
 #endif

--- a/Source/Constants.hpp
+++ b/Source/Constants.hpp
@@ -1,6 +1,6 @@
 /*
 Written by: Daniel Duque
-Last modified on 19 Nov 2019
+Last modified on 04 Mar 2020
 
 Declarations for the Plasma class
 This file contains a corresponding source file.
@@ -13,5 +13,6 @@ const double ePos{ 1.602176634e-19 }; //Elementary positive charge in Coulombs
 const double epsilon{ 8.8541878128e-12 }; //Permittivity of free space in SI units
 const double massE{ 9.1093837015e-31 }; //Electron rest mass in kilograms
 const double PI{ 3.14159265359 };
+const double KB{ 1.38064852e-23 }; //Boltzmann constant in SI
 
 #endif

--- a/Source/PenningTrap.cpp
+++ b/Source/PenningTrap.cpp
@@ -1,6 +1,6 @@
 /*
 Written by: Daniel Duque
-Last modified on 18 Feb 2020
+Last modified on 04 Mar 2020
 
 Definitions for the Electrode and PenningTrap classes
 */
@@ -156,6 +156,13 @@ void PenningTrap::updateRHS()
 			totalLength += electrodes[i].getLength() + gaps[i];
 		}
 	}
+	//Sometimes, if the number of grid cells is large, rounding errors cause the last grid point to be missed
+	//fill the last points missed due to rounding errors with the appropriate end electrode
+	while (point < Nz + 1)
+	{
+		RHS.coeffRef(point + N) = -1 * matrixFactor * electrodes.back().getPotential();
+		point++;
+	}
 }
 void PenningTrap::solveLaplace()
 {
@@ -294,6 +301,13 @@ double PenningTrap::getTotalPhi(int r, int z) const
 		phi += aPlasma.selfPotential.coeff(index);
 	}
 	return phi;
+}
+double PenningTrap::getTotalPhi(int r, double z) const
+{
+	int indexZ{ (int)floor(z / hz) };
+	double dz{ z - indexZ * hz };
+	double weightFactor{ dz / hz };
+	return ((1 - weightFactor) * getTotalPhi(r, indexZ) + weightFactor * getTotalPhi(r, indexZ + 1));
 }
 void PenningTrap::movePlasmas(double deltaT)
 {

--- a/Source/PenningTrap.cpp
+++ b/Source/PenningTrap.cpp
@@ -1,6 +1,6 @@
 /*
 Written by: Daniel Duque
-Last modified on 04 Mar 2020
+Last modified on 11 Mar 2020
 
 Definitions for the Electrode and PenningTrap classes
 */
@@ -339,4 +339,5 @@ void PenningTrap::reserve(int desired)
 	{
 		aPlasma.reserve(desired);
 	}
+	potentialEnergiesHistory.reserve(desired);
 }

--- a/Source/PenningTrap.hpp
+++ b/Source/PenningTrap.hpp
@@ -1,6 +1,6 @@
 /*
 Written by: Daniel Duque
-Last modified on 18 Feb 2020
+Last modified on 04 Mar 2020
 
 Declarations for the Electrode and PenningTrap classes
 This file contains a corresponding source file.
@@ -57,6 +57,7 @@ private:
 	double getEField(int r, int z); //Get E field at one of the grid points
 	double getEField(int r, double z); //Get field anywhere, based on E field at neighbour grid points.
 	double getTotalPhi(int r, int z) const; //Get the sum of the potential fields of the trap plus all the plasmas in a grid point
+	double getTotalPhi(int r, double z) const; //Total sum of Phi at the centre of the trap
 	
 public:
 	PenningTrap(double radius, const std::vector<Electrode>& theElectrodes, const std::vector<double>& theGaps, int NumCellsZ, int NumCellsR);

--- a/Source/PenningTrap.hpp
+++ b/Source/PenningTrap.hpp
@@ -1,6 +1,6 @@
 /*
 Written by: Daniel Duque
-Last modified on 04 Mar 2020
+Last modified on 06 Mar 2020
 
 Declarations for the Electrode and PenningTrap classes
 This file contains a corresponding source file.
@@ -57,7 +57,7 @@ private:
 	double getEField(int r, int z); //Get E field at one of the grid points
 	double getEField(int r, double z); //Get field anywhere, based on E field at neighbour grid points.
 	double getTotalPhi(int r, int z) const; //Get the sum of the potential fields of the trap plus all the plasmas in a grid point
-	double getTotalPhi(int r, double z) const; //Total sum of Phi at the centre of the trap
+	double getTotalPhi(int r, double z) const; //Total sum of Phi anywhere
 	
 public:
 	PenningTrap(double radius, const std::vector<Electrode>& theElectrodes, const std::vector<double>& theGaps, int NumCellsZ, int NumCellsR);

--- a/Source/Plasma.cpp
+++ b/Source/Plasma.cpp
@@ -1,6 +1,6 @@
 /*
 Written by: Daniel Duque
-Last modified on 06 Mar 2020
+Last modified on 07 Mar 2020
 
 Definitions for the Plasma class
 This file contains a corresponding source file.
@@ -430,29 +430,23 @@ void Plasma::loadProfile(double aTemperature, double aTotalCharge, double shape,
 	//this are simply gaussian with the appropriate std deviation as we are looking at 1 dimension only
 	std::default_random_engine generator;
 	std::normal_distribution<double> distribution(0, sqrt(KB * aTemperature / mass));
-	double atZero;
 	for (int indexR = 0; indexR < refTrap.Nr; ++indexR)
 	{
 		double deltaQ{ cumulativeAtR[indexR].back() / (numAtR[indexR] + 1) };
-		double currentInvert{ deltaQ };
 		int currentIndex{ 0 };
-		while (abs(currentInvert) < abs(cumulativeAtR[indexR].back()))
+		for (int i = 0; i < numAtR[indexR]; ++i)
 		{
+			double currentInvert{ deltaQ * (i + 1) };
 			while (abs(cumulativeAtR[indexR][currentIndex]) < abs(currentInvert))
 			{
 				currentIndex++;
 			}
 			//The point to invert is between currentIndex and currentIndex - 1
 			//Assume linear interpolation between this two points
-			double invertedPos{ (currentIndex - 1) * refTrap.hz + refTrap.hz * (currentInvert - cumulativeAtR[indexR][currentIndex - 1]) / (cumulativeAtR[indexR][currentIndex] - cumulativeAtR[indexR][currentIndex - 1]) };
+			double invertedPos{ (currentIndex - 1) * refTrap.hz + refTrap.hz / 2 + refTrap.hz * (currentInvert - cumulativeAtR[indexR][currentIndex - 1]) / (cumulativeAtR[indexR][currentIndex] - cumulativeAtR[indexR][currentIndex - 1]) };
 			rings.push_back(MacroRing(indexR, invertedPos, distribution(generator)));
-			currentInvert += deltaQ;
-		}
-		if (indexR == 0)
-		{
-			atZero = rings.size();
 		}
 	}
-	std::cout << "Loading " << rings.size() << " macro-particles from which " << atZero << " are at r=0.\n";
+	std::cout << "Loading " << rings.size() << " macro-particles from which " << numAtR[0] << " are at r=0.\n";
 	solvePoisson();
 }

--- a/Source/Plasma.cpp
+++ b/Source/Plasma.cpp
@@ -1,9 +1,9 @@
 /*
 Written by: Daniel Duque
-Last modified on 07 Mar 2020
+Last modified on 11 Mar 2020
 
 Definitions for the Plasma class
-This file contains a corresponding source file.
+This file contains a corresponding header file.
 */
 #include"Plasma.hpp"
 
@@ -144,6 +144,10 @@ void Plasma::extractInitialDensity(std::string fileName) const
 	newFile << initialDensity.format(fastFullPrecision);
 	newFile.close();
 }
+int Plasma::getNumMacro() const
+{
+	return rings.size();
+}
 void Plasma::extractHistory(std::string preName) const
 {
 	std::ofstream newPositions, newSpeeds;
@@ -261,6 +265,10 @@ void Plasma::loadOneDUniform(int numMacro, double aTotalCharge, double lengthLin
 	{
 		throw std::logic_error("Charge of MacroRing and the plasma type must have the same sign");
 	}
+	if (numMacro <= 0)
+	{
+		throw std::logic_error("Number of macro-particles has to be a positive integer");
+	}
 	aTotalCharge /= numMacro; //Charge of a single macro-ring
 	chargeMacro = r == 0 ? aTotalCharge : aTotalCharge / (8 * r);
 	macroChargeDensity = 4 * chargeMacro / (PI * refTrap.hz * refTrap.hr * refTrap.hr);
@@ -298,6 +306,10 @@ void Plasma::loadProfile(double aTemperature, double aTotalCharge, double shape,
 	if (aTemperature <= 0 || shape <= 0 || scale <= 0)
 	{
 		throw std::logic_error("Temperature, shape, and scale all need to be positive");
+	}
+	if (numMacro <= 0)
+	{
+		throw std::logic_error("Number of macro-particles has to be a positive integer");
 	}
 	if (aTotalCharge * charge < 0)
 	{
@@ -384,6 +396,99 @@ void Plasma::loadProfile(double aTemperature, double aTotalCharge, double shape,
 		//Now combine both the new and old density based on the KSCorrection
 		//This linear combinations retains the total integral and the profile
 		initialDensity = KSCorrection * previousDensity + (1 - KSCorrection) * initialDensity;
+	}
+	//Ok, now I have a density grid. I need now to populate macro-particles to match this grid density.
+	//How many particles am I placing at each radial index
+	std::vector<std::vector<double>> cumulativeAtR;
+	for (int indexR = 0; indexR < refTrap.Nr; ++indexR)
+	{
+		std::vector<double> cumulative;
+		double volume;
+		if (indexR == 0)
+		{
+			volume = PI * refTrap.hz *  refTrap.hr *  refTrap.hr / 4;
+		}
+		else
+		{
+			volume = refTrap.hz *  refTrap.hr * 2 * PI * indexR *  refTrap.hr;
+		}
+		double aChargeR{ 0 };
+		for (int indexZ = 0; indexZ < refTrap.Nz + 1; ++indexZ)
+		{
+			aChargeR += volume * initialDensity.coeffRef((refTrap.Nz + 1) * indexR + indexZ);
+			cumulative.push_back(aChargeR);
+		}
+		cumulativeAtR.push_back(cumulative);
+	}
+	double futureMacroCharge{ cumulativeAtR[0].back() };
+	for (unsigned int i = 1; i < cumulativeAtR.size(); ++i)
+	{
+		futureMacroCharge += cumulativeAtR[i].back() / (8 * i);
+	}
+	chargeMacro = futureMacroCharge / numMacro;
+	macroChargeDensity = 4 * chargeMacro / (PI * refTrap.hz * refTrap.hr * refTrap.hr);
+	std::vector<int> numAtR;
+	numAtR.push_back((int)round(cumulativeAtR[0].back() / chargeMacro));
+	for (unsigned int i = 1; i < cumulativeAtR.size(); ++i)
+	{
+		numAtR.push_back((int)round(cumulativeAtR[i].back() / (8 * i * chargeMacro)));
+	}
+	//Now I know how many particles I want to place at each radius.
+	//Distribute them using an inverse transform sampling
+	//But without any randomness, just equally space the uniform distribution
+	rings.clear();
+	rings.reserve(numMacro);//this is not exactly the number of particles we will load, but it is close
+	//Use std::random to produce boltzmann distributed speeds
+	//this are simply gaussian with the appropriate std deviation as we are looking at 1 dimension only
+	std::default_random_engine generator;
+	std::normal_distribution<double> distribution(0, sqrt(KB * aTemperature / mass));
+	for (int indexR = 0; indexR < refTrap.Nr; ++indexR)
+	{
+		double deltaQ{ cumulativeAtR[indexR].back() / (numAtR[indexR] + 1) };
+		int currentIndex{ 0 };
+		for (int i = 0; i < numAtR[indexR]; ++i)
+		{
+			double currentInvert{ deltaQ * (i + 1) };
+			while (abs(cumulativeAtR[indexR][currentIndex]) < abs(currentInvert))
+			{
+				currentIndex++;
+			}
+			//The point to invert is between currentIndex and currentIndex - 1
+			//Assume linear interpolation between this two points
+			double invertedPos{ (currentIndex - 1) * refTrap.hz + refTrap.hz / 2 + refTrap.hz * (currentInvert - cumulativeAtR[indexR][currentIndex - 1]) / (cumulativeAtR[indexR][currentIndex] - cumulativeAtR[indexR][currentIndex - 1]) };
+			rings.push_back(MacroRing(indexR, invertedPos, distribution(generator)));
+		}
+	}
+	std::cout << "Loading " << rings.size() << " macro-particles from which " << numAtR[0] << " are at r=0.\n";
+	solvePoisson();
+}
+void Plasma::loadDensityFile(std::string fileName, double aTemperature, int numMacro)
+{
+	//The file should just be a single column, in the same way the output of initialDensity is given if you loadProfile for example
+	//Check input makes sense
+	if (aTemperature <= 0)
+	{
+		throw std::logic_error("Temperature needs to be positive");
+	}
+	if (numMacro <= 0)
+	{
+		throw std::logic_error("Number of macro-particles has to be a positive integer");
+	}
+	temperature = aTemperature;
+	//Read the file into the initial density
+	initialDensity.setZero(refTrap.Nz * refTrap.Nr + refTrap.Nr);
+	//Assume the file is in the correct format.
+	double readNumber;
+	std::ifstream rFile(fileName);
+	int currentIndex{ 0 };
+	while (rFile >> readNumber)
+	{
+		initialDensity.coeffRef(currentIndex) = readNumber;
+		++currentIndex;
+	}
+	if (currentIndex != refTrap.Nz * refTrap.Nr + refTrap.Nr)
+	{
+		throw std::logic_error("The number of grid points in the file do not match this trap.");
 	}
 	//Ok, now I have a density grid. I need now to populate macro-particles to match this grid density.
 	//How many particles am I placing at each radial index

--- a/Source/Plasma.hpp
+++ b/Source/Plasma.hpp
@@ -1,6 +1,6 @@
 /*
 Written by: Daniel Duque
-Last modified on 06 Mar 2020
+Last modified on 11 Mar 2020
 
 Declarations for the Plasma class
 This file contains a corresponding source file.
@@ -69,6 +69,7 @@ public:
 	void extractSelfPotential(std::string fileName) const;//Store the potential field in a document called filename
 	void extractPlasmaParameters(std::string filename) const;//Extract the plasma parameters
 	void extractInitialDensity(std::string filename) const;//This is NOT the actual initial density obtained from macro-Particles. This is the EXPECTED initial density
+	int getNumMacro() const;//Return the current number of macro-particles still in the trap
 	//Loading routines
 	/*----------------------------------------------------------------------------------
 	These routines below are the only thing that you should change/add to the code.
@@ -87,6 +88,8 @@ public:
 	void loadOneDUniform(int numMacro, double totalCharge, double lengthLine, int r); //equally spaced particles at fixed r in a length centred in the center of the trap.
 	void loadSingleRing(double totalCharge, int r, double Z, double speed); //Single ring at a position with a velocity
 	void loadProfile(double aTemperature, double totalCharge, double shape, double scale, int numMacro, double KSThreshold); //Load using a density profile (as obtained from MCP), shape and scale define the generalized normal fit. Assume local thermal equilibrium along each radius
+	void loadDensityFile(std::string fileName, double aTemperature, int numMacro);
+
 };
 
 #endif

--- a/Source/Plasma.hpp
+++ b/Source/Plasma.hpp
@@ -1,6 +1,6 @@
 /*
 Written by: Daniel Duque
-Last modified on 10 Dec 2019
+Last modified on 04 Mar 2020
 
 Declarations for the Plasma class
 This file contains a corresponding source file.
@@ -47,7 +47,9 @@ private:
 	double chargeMacro; //Charge of each MacroRing, all rings have the same charge regardless of r position.
 	double massMacro; //Mass of each MacroRing.
 	std::vector<MacroRing> rings;
-	//double temperature;
+	double temperature;
+	double totalCharge;
+	double centralDensity;
 	Eigen::VectorXd selfPotential{ refTrap.Nz * refTrap.Nr + refTrap.Nr };
 	Eigen::VectorXd RHS{ refTrap.Nz * refTrap.Nr + refTrap.Nr };// = - charge density / permittivity of free space
 	void updateRHS();
@@ -57,12 +59,17 @@ private:
 	void reserve(int desired);
 	void extractHistory(std::string preName) const;
 	double getPotentialEnergy() const;
+	Eigen::VectorXd initialDensity{ refTrap.Nz * refTrap.Nr + refTrap.Nr };// Initial density with which the plasma was loaded
+	void estimateDensityProportions(); //Estimate the densities w.r.t. central densities in local thermal equilibrium from total potential. i.e. a value of 1 for all radius at the centre. Need to determine the actual values based on the profile
+	void fitDensityProportionToProfile(double shape, double scale); //Weight each radius to match the desired profile
+	void normalizeDensityToTotalCharge(); //Weight each radius so that the total charge matches the desired total charge
 public:
 	Plasma(PenningTrap& trap, std::string name, double mass, double charge);
 	~Plasma();
 	friend PenningTrap;
 	void extractSelfPotential(std::string fileName) const;//Store the potential field in a document called filename
 	void extractPlasmaParameters(std::string filename) const;//Extract the plasma parameters
+	void extractInitialDensity(std::string filename) const;
 	//Loading routines
 	/*----------------------------------------------------------------------------------
 	These routines below are the only thing that you should change/add to the code.
@@ -80,6 +87,7 @@ public:
 	-------------------------------------------------------------------------------------*/
 	void loadOneDUniform(int numMacro, double chargeMacro, double lengthLine, int r); //equally spaced particles at fixed r in a length centred in the center of the trap.
 	void loadSingleRing(double chargeMacro, int r, double Z, double speed); //Single ring at a position with a velocity
+	void loadProfile(double aTemperature, double totalCharge, double shape, double scale, int numMacro, double KSThreshold); //Load using a density profile (as obtained from MCP), shape and scale define the generalized normal fit. Assume local thermal equilibrium along each radius
 };
 
 #endif


### PR DESCRIPTION
Can load a single species plasma using a profile density obtained from an MCP image.
Can also load using a density file grid (usually just  to speed things up, calculate the density grid once with MCP load, and then reuse this initial density grid).